### PR TITLE
create room, with picture url

### DIFF
--- a/org_api/views/room.py
+++ b/org_api/views/room.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from django.contrib.auth.models import User
 
 from org_api.models import Room
+from org_api.models import organizer
 from org_api.models.organizer import Organizer
 from org_api.serializers import OrganizerSerializer, RoomSerializer
 
@@ -40,3 +41,21 @@ class RoomView(ViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Room.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+    def create(self, request):
+        """ Handles the POST request to create a new room for the user.
+
+        Returns:
+            Response: JSON serialized room instance
+        """
+
+        organizer = Organizer.objects.get(user=request.auth.user)
+
+        room = Room.objects.create(
+            name=request.data["name"],
+            org=organizer,
+            picture=request.data["picture"],
+            private=False
+        )
+        serializer = RoomSerializer(room)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
# Description

Added create room method to room.py.  For MVP, not using the private feature, so it is defaulted to false.  Currently it is working with using a picture URL, to testing ease, will be updating code to allow for picture uploads, in the next PR.

<!-- Add in the issue number here-->
Fixes # 5

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Please describe the steps that you ran to verify your changes. Provide instructions so reviewer can follow those steps.

- [x] In postman run the following to POST to http://localhost:8000/rooms. 
{
    "name": "Scuba",
    "picture": "https://assets3.thrillist.com/v1/image/2792509/1200x630/flatten;crop_down;webp=auto;jpeg_quality=70"
}
201 status should return with the user being pulled from the token used, and private defaulted to false.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes